### PR TITLE
Transmit: First draft based on sending blocks and four registers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,65 @@ Design goals:
 
 EasyNIC is inspired by the success of RISC-V.
 
-# Functions
+# Transmit
 
-## Transmit
-## Receive
-## Diagnostics
+The host provides packets to the NIC in variable-size *blocks* that
+each contain a series of packets. Each packet is represented by a
+16-bit `LENGTH` field followed by `PAYLOAD` of the corresponding
+size. The end of the block is indicated with a `LENGTH` of zero.
+
+Note: The Ethernet FCS is automatically calculated and appended.
+
+Registers:
+
+    TX_BLOCK_SEND [Write]:
+
+      Write the 64-bit address of a block and enqueue it for
+      transmission.
+
+      Multiple writes cause blocks to be transmitted in FIFO order.
+
+      This register must only be written when TX_BLOCK_AVAIL and
+      TX_READY read non-zero.
+
+    TX_BLOCK_AVAIL [Read]
+
+      Read how many more blocks can be enqueued at the current time.
+
+      The value is determined strictly as follows:
+
+      - Initialized to a device-specific constant (e.g. 1024);
+      - Decreases by 1 when a new block is enqueued;
+      - Increases by 1 when a block completes.
+
+      The host can poll this value to track which blocks have been
+      completed.
+
+      This register must only be read when TX_READY reads non-zero.
+
+    TX_RESET [Write]
+
+      Write the value 1 to initiate an asynchronous reset of the device
+      transmit state. This potentially discards the contents of enqueued
+      blocks.
+
+      Completion of the reset can be detected via TX_READY. Upon
+      completion the value of TX_BLOCK_AVAIL will have been reset to its
+      initial value.
+
+    TX_READY [Read]
+
+      Read whether the device is ready to transmit data.
+
+      The value is determined strictly as follows:
+
+      - Initialized to 0 on startup.
+      - Transitions to 1 when ready.
+      - Transitions back to 0 when a reset is requested.
+
+      The host driver should therefore poll for a non-zero value during
+      initialization and after each asynchronous reset.
+
+# Receive
+# Diagnostics
 


### PR DESCRIPTION
Here is a first proposal for the (single-queue) transmit interface.

This is a novel (?) design where the host posts buffer addresses to an MMIO register and each buffer can contain any number of packets.

Efficient operation will require the host to assemble packets together in memory specially for the card. This should be simple, and efficient from a PCIe perspective (#3), but will require some cycles and cache/memory bandwidth.

Good trade-off? (Been done before? Better to do another way?)